### PR TITLE
Bar chart ticks

### DIFF
--- a/public/js/createBarChart.js
+++ b/public/js/createBarChart.js
@@ -1,3 +1,7 @@
+/*
+Good basic D3 axes tutorial: https://ghenshaw-work.medium.com/customizing-axes-in-d3-js-99d58863738b
+*/
+
 function createBarChart(data, options = {}) {
   canvasSelector = options.canvasSelector || 'svg';
   var svg = d3.select(canvasSelector),
@@ -21,8 +25,10 @@ function createBarChart(data, options = {}) {
     .text(chartTitle);
 
   // determine x and y scales
-  var xScale = d3.scaleBand().range([0, width]).padding(0.4),
-    yScale = d3.scaleLinear().range([height, 0]);
+  // scaleBand for X because we have discrete values (dates)
+  // scaleLinear for Y because we have continuous values (integers)
+  var xScale = d3.scaleBand().range([0, width]).padding(0.4);
+  var yScale = d3.scaleLinear().range([height, 0]);
 
   // place graph in svg
   var g = svg
@@ -42,16 +48,42 @@ function createBarChart(data, options = {}) {
     }),
   ]);
 
+  // add x axis
+  let xAxisGenerator = d3.axisBottom(xScale);
+
+  // manage frequency of x axis labels so they don't overlap
+  // based on: https://stackoverflow.com/questions/40199108/d3-v4-scaleband-ticks
+  let numPoints = xScale.domain().length;
+  if (numPoints > 10) {
+    nthTick = Math.floor(numPoints / 10);
+    xAxisGenerator.tickValues(
+      xScale.domain().filter(function (d, i) {
+        return !(i % nthTick);
+      })
+    );
+  }
+
   // add x-axis label
-  g.append('g')
-    .attr('transform', 'translate(0,' + height + ')')
-    .call(d3.axisBottom(xScale))
+  g.append('g') // create group for x-axis
+    .attr('class', 'axis axis--x') // add class to x-axis
+    .attr('transform', 'translate(0,' + height + ')') // position at bottom of chart
+    .call(xAxisGenerator) // render x-axis
     .append('text')
     .attr('y', height - 1.25 * margin)
     .attr('x', width - halfMargin)
     .attr('text-anchor', 'end')
     .attr('stroke', 'black')
     .text(xAxisLabel);
+
+  g.select('.axis--x')
+    .selectAll('tick')
+    .style('opacity', function (d) {
+      if (d3.select(this).text().match('[0-9]{4}-[0-9]{2}-01')) {
+        return '1';
+      } else {
+        return '0';
+      }
+    });
 
   // add y-axis ticks, values and label
   g.append('g')

--- a/public/js/createBarChart.js
+++ b/public/js/createBarChart.js
@@ -54,8 +54,13 @@ function createBarChart(data, options = {}) {
   // manage frequency of x axis labels so they don't overlap
   // based on: https://stackoverflow.com/questions/40199108/d3-v4-scaleband-ticks
   let numPoints = xScale.domain().length;
+  let nthTick;
   if (numPoints > 10) {
-    nthTick = Math.floor(numPoints / 10);
+    if (numPoints < 20) {
+      nthTick = 2;
+    } else {
+      nthTick = Math.floor(numPoints / 10);
+    }
     xAxisGenerator.tickValues(
       xScale.domain().filter(function (d, i) {
         return !(i % nthTick);


### PR DESCRIPTION
* don't show every tick
* if more than 10 ticks on a bar chart, show only ten (with labels) evenly spaced along the x axis
* partially addresses #78