### PR TITLE
nav items default to aria-selected=false

### DIFF
--- a/views/index.ejs
+++ b/views/index.ejs
@@ -150,7 +150,8 @@
                   <li class="nav-item m-2" role="presentation">
                     <% let tabId=s.replace( /[^a-zA-Z0-9]+/g, '_' ); %>
                       <button class="text-start nav-link text-light ps-3 border-0" id="<%= tabId %>-tab-mobile"
-                        data-bs-toggle="tab" data-bs-target="#<%= tabId %>" role="tab" aria-controls="<%= s %>">
+                        data-bs-toggle="tab" data-bs-target="#<%= tabId %>" role="tab" aria-controls="<%= s %>"
+                        aria-selected="false">
                         <i class="bi bi-caret-right-fill mr-1"></i>
                         <%= s %>
                       </button>
@@ -198,7 +199,8 @@
               <li class="nav-item m-2" role="presentation">
                 <% let tabId=s.replace( /[^a-zA-Z0-9]+/g, '_' ); %>
                   <button class="text-start nav-link text-light ps-3 border-0" id="<%= tabId %>-tab"
-                    data-bs-toggle="tab" data-bs-target="#<%= tabId %>" role="tab" aria-controls="<%= s %>">
+                    data-bs-toggle="tab" data-bs-target="#<%= tabId %>" role="tab" aria-controls="<%= s %>"
+                    aria-selected="false">
                     <i class="bi bi-caret-right-fill mr-1"></i>
                     <%= s %>
                   </button>


### PR DESCRIPTION
* closes #124
* subject nav buttons default to `aria-selected=false` to avoid confusing screen readers that think every time you tab over a link it's selected 