### PR TITLE
use Logger instead of console for most in-app logs

### DIFF
--- a/controllers/UserDataController.js
+++ b/controllers/UserDataController.js
@@ -15,6 +15,8 @@ const UserFavoritesController = require('./UserFavoritesController');
 let appConf = config.get('app');
 const useFavorites = appConf.useFavorites || false;
 const fakeUserConf = require('../config/fakeUserConf.json');
+const approot = require('app-root-path');
+const Logger = require(approot + '/helpers/Logger');
 
 module.exports = class UserDataController {
   constructor(req) {
@@ -27,7 +29,7 @@ module.exports = class UserDataController {
           let fakeUserFile = fakeUserConf.fakeUsers.filter(
             (p) => p.id === fakeUserId
           )[0].file;
-          console.log(fakeUserId, fakeUserFile);
+          Logger.log('Using fake user:', fakeUserId, fakeUserFile);
           this.rawUserData = require(__dirname +
             '/../fakeUsers/' +
             fakeUserFile);

--- a/helpers/favoritesValidation.js
+++ b/helpers/favoritesValidation.js
@@ -1,4 +1,5 @@
 const config = require('config');
+const approot = require('app-root-path');
 const Logger = require('../helpers/Logger');
 const Databases = require('../cache/Databases');
 const Guides = require('../cache/Guides');
@@ -11,7 +12,7 @@ subjectNames = Subjects.map((subject) => subject.name);
 
 function validateInput(input, type) {
   if (type === 'database') {
-    console.log('Validating db id: ' + input, dbIds.includes(parseInt(input)));
+    // console.log('Validating db id: ' + input, dbIds.includes(parseInt(input)));
     return dbIds.includes(parseInt(input));
   } else if (type === 'guide') {
     return guideIds.includes(parseInt(input));

--- a/helpers/getFavoritesStats.js
+++ b/helpers/getFavoritesStats.js
@@ -1,13 +1,15 @@
 const FavoritesStatsApi = require('../models/userFavorites/FavoritesStatsApi');
 const favs = new FavoritesStatsApi();
 const fs = require('fs').promises;
+const approot = require('app-root-path');
+const Logger = require(approot + '/helpers/Logger');
 
 const getFavStats = async function () {
   try {
     await favs.GetAllUserFavorites();
     return favs.getStats();
   } catch (err) {
-    console.error(err);
+    Logger.error({ message: err.message, error: err });
   }
 };
 

--- a/helpers/reportUsage.js
+++ b/helpers/reportUsage.js
@@ -10,7 +10,7 @@ reportUsage = function (data, increment, options = {}) {
 
   opts = getOpts(data, options);
   data = applyDataLimiters(data, opts);
-  console.log(opts);
+  // console.log(opts);
 
   if (increment == 'all') {
     let json = {

--- a/models/circulation/sierra/SierraDataGetter.js
+++ b/models/circulation/sierra/SierraDataGetter.js
@@ -1,4 +1,6 @@
 const SierraApi = require('./SierraApi');
+const approot = require('app-root-path');
+const Logger = require(approot + '/helpers/Logger');
 
 module.exports = class SierraDataGetter {
   constructor(conf) {
@@ -12,7 +14,7 @@ module.exports = class SierraDataGetter {
     try {
       await this.sierra.getToken();
     } catch (err) {
-      console.error('Error getting accessToken:', err);
+      Logger.error({ message: 'Error getting accessToken', error: err });
     }
 
     try {
@@ -23,7 +25,10 @@ module.exports = class SierraDataGetter {
       this.getAccountLink();
       return this.user.display;
     } catch (err) {
-      console.error('Error getting patron info from Sierra');
+      Logger.error({
+        message: 'Error getting patron info from Sierra',
+        error: err,
+      });
     }
   }
 
@@ -45,7 +50,7 @@ module.exports = class SierraDataGetter {
       this.user.numericId = res.data.id;
       this.user.display.moneyOwed = res.data.moneyOwed;
     } catch (err) {
-      console.log(err);
+      Logger.error({ message: err.message, error: err });
     }
   }
   async getNumCheckouts() {
@@ -53,7 +58,7 @@ module.exports = class SierraDataGetter {
       let res = await this.sierra.patronQuery('checkouts', this.user.numericId);
       this.user.display.numCheckouts = res.data.total;
     } catch (err) {
-      console.log(err);
+      Logger.error({ message: err.message, error: err });
     }
   }
   async getNumHolds() {
@@ -61,7 +66,7 @@ module.exports = class SierraDataGetter {
       let res = await this.sierra.patronQuery('holds', this.user.numericId);
       this.user.display.numHolds = res.data.total;
     } catch (err) {
-      console.log(err);
+      Logger.error({ message: err.message, error: err });
     }
   }
   getAccountLink() {

--- a/models/userLoginData/UserLibGuidesData.js
+++ b/models/userLoginData/UserLibGuidesData.js
@@ -2,6 +2,7 @@ const LibAppsDataFilter = require('../libGuides/LibAppsDataFilter');
 const f = new LibAppsDataFilter();
 const path = require('path');
 const fs = require('fs');
+const approot = require('app-root-path');
 const Logger = require('../../helpers/Logger');
 
 module.exports = class UserLibGuidesData {
@@ -82,8 +83,8 @@ module.exports = class UserLibGuidesData {
       this.favorites.favoriteGuides !== undefined &&
       contents.guides !== undefined
     ) {
-      console.log(contents);
-      console.log('ended contents');
+      // console.log(contents);
+      // console.log('ended contents');
       contents.guides.forEach((guide) => {
         guide.favorite = this.favorites.favoriteGuides.includes(guide.id);
       });

--- a/utilities/auditContentSecurityPolicy.js
+++ b/utilities/auditContentSecurityPolicy.js
@@ -1,6 +1,8 @@
 const approot = require('app-root-path');
 const Librarians = require(approot + '/cache/Librarians');
 const cspPolicy = require(approot + '/helpers/contentSecurityPolicy');
+const approot = require('app-root-path');
+const Logger = require(approot + '/helpers/Logger');
 
 function elementsInFirstArray(a, b) {
   return a.filter((element) => !b.includes(element));
@@ -68,7 +70,7 @@ async function categorizeUrlsFromObjects(objectsArray) {
 
     return categorizedDomains;
   } catch (error) {
-    console.error('Error categorizing URLs from objects:', error);
+    Logger.error({ message: 'Error categorizing URLs from objects', error });
     return { images: {}, javascripts: {}, webpages: {} };
   }
 }
@@ -79,20 +81,20 @@ categorizeUrlsFromObjects(Librarians)
     jsSrcDomains = Object.keys(categorizedDomains.javascripts);
     webSrcDomains = Object.keys(categorizedDomains.webpages);
 
-    console.log(
+    Logger.log(
       // list imgSrcDomains not in cspPolicy.imgSrc
       'Image domains missing from cspPolicy.imgSrc:',
       elementsInFirstArray(imgSrcDomains, cspPolicy.imgSrc)
     );
-    console.log(
+    Logger.log(
       'Script domains missing from cspPolicy.scriptSrc:',
       elementsInFirstArray(jsSrcDomains, cspPolicy.scriptSrc)
     );
-    console.log(
+    Logger.log(
       'Webpage domains missing from cspPolicy.defaultSrc:',
       elementsInFirstArray(webSrcDomains, cspPolicy.defaultSrc)
     );
   })
   .catch((error) => {
-    console.error('Error categorizing URLs from objects:', error);
+    Logger.error({ message: 'Error categorizing URLs from objects', error });
   });

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -15,7 +15,7 @@
       // if left arrow in main, jump from main panel to nav
       $('.tab-pane').keydown(function (e) {
         if (e.keyCode == 37) {
-          console.log('attempting to go left')
+          // console.log('attempting to go left')
           $('.nav-item button[aria-selected="true"]').focus();
         }
       });


### PR DESCRIPTION
console.log is still used for a bunch of stuff that interacts with the command line, but in-app logging should be done through Logger. 

There are some in-app places that have console.log calls that are commented out. Those may be used for debugging in the development process, but are not expected to be needed for server logging

closes #194 