### PR TITLE
include sierra config and prod database in config/default_sample.json

### DIFF
--- a/config/default_sample.json
+++ b/config/default_sample.json
@@ -22,7 +22,8 @@
             "note": "Content Security Policy (CSP) is a computer security standard introduced to prevent cross-site scripting (XSS) attacks. Add to the following all servers from which your local settings will call scripts, etc.. This may include Google Analytics, LibCal, LibGuides, and other sources. Include just the fully qualified domains as an array of strings",
             "defaultSrcAdditions": [],
             "scriptSrcAdditions": [],
-            "imgSrcAdditions": [], // currently recommended: "*.cloudfront.net" to load widget images
+            "_imgSrcAdditionsNote": "// currently recommended: '*.cloudfront.net' to load widget images",
+            "imgSrcAdditions": [], 
             "frameSrcAdditions": []
         }
     },
@@ -41,11 +42,31 @@
         "serverPath": "https://casserver.yourorg.edu",
         "exposeStatsOutsideCas": false
     },
+    "circSystem": "Sierra",
+    "sierra": {
+        "credentials": {
+            "apiKey": "6ptSactEH4mcMcm45cJYjKeY5Zge",
+            "clientSecret": "68UYZ!u8t@U6PiNBus7p"
+        },
+        "server": "holmes.lib.miamioh.edu",
+        "apiPath": "/iii/sierra-api",
+        "endpoints": {
+            "token": "/v6/token"
+        }
+    },
     "database": {
         "use": "dev",
         "dev": {
             "host": "localhost",
             "connection": "mongodb://localhost:27017/MyGuide?readPreference=primary&appname=MongoDB%20Compass&directConnection=true&ssl=false",
+            "config": {
+                "useNewUrlParser": true,
+                "useUnifiedTopology": true
+            }
+        },
+        "prod": {
+            "host": "your.cluster.mongodb.net",
+            "connection": "mongodb+srv://user:password@your.cluster.mongodb.net/MyGuideProd?retryWrites=true&w=majority",
             "config": {
                 "useNewUrlParser": true,
                 "useUnifiedTopology": true


### PR DESCRIPTION
* adds Sierra circulation config 
* moves imgSrcAdditions explanation from an illegal '// comment' to a JSON comment field
* adds an example of multiple database configs to the default_sample config