### PR TITLE
Sort guides and databases

### DIFF
--- a/models/circulation/test/AlmaDataGetter.test.js
+++ b/models/circulation/test/AlmaDataGetter.test.js
@@ -68,6 +68,7 @@ describe('AlmaDataGetter: getUserData', () => {
       numCheckouts: 14,
       numHolds: 2,
       fines: 35.54,
+      accountLink: 'https://fake.account.link',
     });
     expect(getter.user.display.numCheckouts).toBe(14);
     expect(getter.user.display.numHolds).toBe(2);

--- a/models/circulation/test/sample-data/fakeAlmaConfig.yml
+++ b/models/circulation/test/sample-data/fakeAlmaConfig.yml
@@ -4,3 +4,4 @@ alma:
     apiKey: fakeApiKey
   server: api-eu.hosted.exlibrisgroup.com
   apiPath: /almaws
+  accountLink: https://fake.account.link

--- a/models/libGuides/LibAppsDataFilter.js
+++ b/models/libGuides/LibAppsDataFilter.js
@@ -135,6 +135,9 @@ module.exports = class LibAppsDataFilter {
     } else {
       if (dbSort) {
         done = this.sortDatabases(done, subjects);
+      } else if (done[0].hasOwnProperty('name')) {
+        // console.log(JSON.stringify(done, null, 2));
+        done = this.alphaSortByProperty(done, 'name');
       }
       return done;
     }
@@ -162,9 +165,6 @@ module.exports = class LibAppsDataFilter {
     // adds a "sortable" value on the database object equal to the featured value for the first subject
     // but changes 0 to 1000 so non-featured come last in the list
     return dbs.map((db) => {
-      // console.log('db has subjects: ', db.hasOwnProperty('subjects'));
-      // console.log('first subject name: ', db.subjects[0].name);
-      // console.log(`looking for ${subjects[0]} among the subjects`);
       let relevantDbSubjectEntry = db.subjects?.find((subj) => {
         return subj.name == subjects[0];
       });
@@ -177,10 +177,25 @@ module.exports = class LibAppsDataFilter {
     });
   }
 
+  alphaSortByProperty(arr, property) {
+    arr.sort((a, b) => {
+      const nameA = a[property].toUpperCase(); // Case-insensitive comparison
+      const nameB = b[property].toUpperCase();
+
+      if (nameA < nameB) {
+        return -1;
+      }
+      if (nameA > nameB) {
+        return 1;
+      }
+      return 0; // names must be equal
+    });
+    return arr;
+  }
+
   sortDatabases(dbs, subjects) {
     // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
     // then do an alpha sort of featured == 0 and append to the end
-    console.log('SortDBs: ' + subjects.join(';') + ': ' + dbs.length);
     const output = [];
     const sortable = this.addSubjectSortVariable(dbs, subjects);
 
@@ -192,14 +207,7 @@ module.exports = class LibAppsDataFilter {
       delete obj.sortable;
     });
     output.push(sortable);
-    // console.log(output);
-    // // alpha sort of featured == 0
-    // zeros.sort((a, b) => {
-    //   return a.name.localeCompare(b.name);
-    // });
 
-    // // append zeros to output
-    // output.push(zeros);
     return output.flat();
   }
 };

--- a/models/libGuides/LibAppsDataFilter.js
+++ b/models/libGuides/LibAppsDataFilter.js
@@ -155,28 +155,6 @@ module.exports = class LibAppsDataFilter {
     return [];
   }
 
-  alphaSortByProperty(arr, property) {
-    arr.sort((a, b) => {
-      const nameA = a[property].toUpperCase(); // Case-insensitive comparison
-      const nameB = b[property].toUpperCase();
-
-      if (nameA < nameB) {
-        return -1;
-      }
-      if (nameA > nameB) {
-        return 1;
-      }
-      return 0; // names must be equal
-    });
-    return arr;
-  }
-
-  numericSortByProperty(arr, property) {
-    arr.sort((a, b) => {
-      return a[property] - b[property];
-    });
-    return arr;
-  }
   sortDatabases(dbs) {
     // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
     // then do an alpha sort of featured == 0 and append to the end
@@ -186,13 +164,18 @@ module.exports = class LibAppsDataFilter {
     const zeros = dbs.filter((item) => item.featured == 0);
 
     // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
+    featured.sort((a, b) => {
+      return a.featured - b.featured || a.name.localeCompare(b.name);
+    });
+    output.push(featured);
 
     // alpha sort of featured == 0
-    const zerosSorted = this.alphaSort(zeros);
+    zeros.sort((a, b) => {
+      return a.name.localeCompare(b.name);
+    });
 
     // append zeros to output
-    output.push(zerosSorted);
-
-    return output;
+    output.push(zeros);
+    return output.flat();
   }
 };

--- a/models/libGuides/LibAppsDataFilter.js
+++ b/models/libGuides/LibAppsDataFilter.js
@@ -108,7 +108,7 @@ module.exports = class LibAppsDataFilter {
     return matches;
   }
 
-  getBestBySubject(resourceList, subjects, topOnly = false) {
+  getBestBySubject(resourceList, subjects, topOnly = false, dbSort = false) {
     // expects resourceList to be an object listing database, librarians, or libguides
     // expect subjects to be an array of subject areas in order of best fit, e.g.:
     // subjects = ['English','Languages']
@@ -160,7 +160,7 @@ module.exports = class LibAppsDataFilter {
     // but changes 0 to 1000 so non-featured come last in the list
     dbs.map((db) => {
       let relevantDbSubjectEntry = db.subjects.find(
-        (subj) => subj.name == subjects[0]
+        (subj) => subj.name == subjects[0].name
       );
       if (relevantDbSubjectEntry.featured == 0) {
         db.sortable = 1000;

--- a/models/libGuides/LibAppsDataFilter.js
+++ b/models/libGuides/LibAppsDataFilter.js
@@ -133,6 +133,9 @@ module.exports = class LibAppsDataFilter {
     if (done === undefined) {
       return [];
     } else {
+      if (dbSort) {
+        done = this.sortDatabases(done, subjects);
+      }
       return done;
     }
   }
@@ -158,23 +161,26 @@ module.exports = class LibAppsDataFilter {
   addSubjectSortVariable(dbs, subjects) {
     // adds a "sortable" value on the database object equal to the featured value for the first subject
     // but changes 0 to 1000 so non-featured come last in the list
-    dbs.map((db) => {
-      let relevantDbSubjectEntry = db.subjects.find(
-        (subj) => subj.name == subjects[0].name
-      );
-      if (relevantDbSubjectEntry.featured == 0) {
+    return dbs.map((db) => {
+      // console.log('db has subjects: ', db.hasOwnProperty('subjects'));
+      // console.log('first subject name: ', db.subjects[0].name);
+      // console.log(`looking for ${subjects[0]} among the subjects`);
+      let relevantDbSubjectEntry = db.subjects?.find((subj) => {
+        return subj.name == subjects[0];
+      });
+      if (relevantDbSubjectEntry?.featured == 0) {
         db.sortable = 1000;
       } else {
-        db.sortable = relevantDbSubjectEntry.featured;
+        db.sortable = relevantDbSubjectEntry?.featured;
       }
+      return db;
     });
-    return dbs;
   }
 
   sortDatabases(dbs, subjects) {
     // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
     // then do an alpha sort of featured == 0 and append to the end
-
+    console.log('SortDBs: ' + subjects.join(';') + ': ' + dbs.length);
     const output = [];
     const sortable = this.addSubjectSortVariable(dbs, subjects);
 
@@ -186,7 +192,7 @@ module.exports = class LibAppsDataFilter {
       delete obj.sortable;
     });
     output.push(sortable);
-
+    // console.log(output);
     // // alpha sort of featured == 0
     // zeros.sort((a, b) => {
     //   return a.name.localeCompare(b.name);

--- a/models/libGuides/LibAppsDataFilter.js
+++ b/models/libGuides/LibAppsDataFilter.js
@@ -84,7 +84,7 @@ module.exports = class LibAppsDataFilter {
       if (item.subjects !== undefined) {
         if (topOnly) {
           var temp = item.subjects.filter(
-            (s) => s.name === subject && s.featured === 1
+            (s) => s.name === subject && s.featured > 0
           );
         } else {
           var temp = item.subjects.filter((s) => s.name === subject);
@@ -153,5 +153,46 @@ module.exports = class LibAppsDataFilter {
         .filter((item) => item !== undefined);
     }
     return [];
+  }
+
+  alphaSortByProperty(arr, property) {
+    arr.sort((a, b) => {
+      const nameA = a[property].toUpperCase(); // Case-insensitive comparison
+      const nameB = b[property].toUpperCase();
+
+      if (nameA < nameB) {
+        return -1;
+      }
+      if (nameA > nameB) {
+        return 1;
+      }
+      return 0; // names must be equal
+    });
+    return arr;
+  }
+
+  numericSortByProperty(arr, property) {
+    arr.sort((a, b) => {
+      return a[property] - b[property];
+    });
+    return arr;
+  }
+  sortDatabases(dbs) {
+    // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
+    // then do an alpha sort of featured == 0 and append to the end
+
+    const output = [];
+    const featured = dbs.filter((item) => item.featured > 0);
+    const zeros = dbs.filter((item) => item.featured == 0);
+
+    // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
+
+    // alpha sort of featured == 0
+    const zerosSorted = this.alphaSort(zeros);
+
+    // append zeros to output
+    output.push(zerosSorted);
+
+    return output;
   }
 };

--- a/models/libGuides/LibAppsDataFilter.js
+++ b/models/libGuides/LibAppsDataFilter.js
@@ -155,27 +155,45 @@ module.exports = class LibAppsDataFilter {
     return [];
   }
 
-  sortDatabases(dbs) {
+  addSubjectSortVariable(dbs, subjects) {
+    // adds a "sortable" value on the database object equal to the featured value for the first subject
+    // but changes 0 to 1000 so non-featured come last in the list
+    dbs.map((db) => {
+      let relevantDbSubjectEntry = db.subjects.find(
+        (subj) => subj.name == subjects[0]
+      );
+      if (relevantDbSubjectEntry.featured == 0) {
+        db.sortable = 1000;
+      } else {
+        db.sortable = relevantDbSubjectEntry.featured;
+      }
+    });
+    return dbs;
+  }
+
+  sortDatabases(dbs, subjects) {
     // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
     // then do an alpha sort of featured == 0 and append to the end
 
     const output = [];
-    const featured = dbs.filter((item) => item.featured > 0);
-    const zeros = dbs.filter((item) => item.featured == 0);
+    const sortable = this.addSubjectSortVariable(dbs, subjects);
 
     // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
-    featured.sort((a, b) => {
-      return a.featured - b.featured || a.name.localeCompare(b.name);
+    sortable.sort((a, b) => {
+      return a.sortable - b.sortable || a.name.localeCompare(b.name);
     });
-    output.push(featured);
-
-    // alpha sort of featured == 0
-    zeros.sort((a, b) => {
-      return a.name.localeCompare(b.name);
+    sortable.forEach((obj) => {
+      delete obj.sortable;
     });
+    output.push(sortable);
 
-    // append zeros to output
-    output.push(zeros);
+    // // alpha sort of featured == 0
+    // zeros.sort((a, b) => {
+    //   return a.name.localeCompare(b.name);
+    // });
+
+    // // append zeros to output
+    // output.push(zeros);
     return output.flat();
   }
 };

--- a/models/libGuides/test/LibAppsDataFilter.test.js
+++ b/models/libGuides/test/LibAppsDataFilter.test.js
@@ -10,7 +10,6 @@ const {
   sortableDbs,
   expectedSortByEnglish,
   expectedSortBySpanish,
-  expectedSortByBoth,
 } = require('./sample-data/libapps/db-sort-sample.js');
 
 describe('LibAppsDataFilter', () => {
@@ -261,16 +260,22 @@ describe('sortDatabases', () => {
   // then do an alpha sort of featured == 0 and append to the end
   it('should correctly sort English databases numerically and then alphabetically', () => {
     const sortedData = obj.sortDatabases(sortableDbs, ['English']);
-    expect(sortedData).toEqual(expectedSortByEnglish);
+    expect(JSON.stringify(sortedData)).toEqual(
+      JSON.stringify(expectedSortByEnglish)
+    );
   });
   it('should correctly sort Spanish databases numerically and then alphabetically', () => {
     const sortedData = obj.sortDatabases(sortableDbs, ['Spanish']);
-    expect(sortedData).toEqual(expectedSortBySpanish);
+    expect(JSON.stringify(sortedData)).toEqual(
+      JSON.stringify(expectedSortBySpanish)
+    );
   });
-  // it('should correctly sort [English+Spanish] databases numerically and then alphabetically', () => {
-  //   const sortedData = obj.sortDatabases(sortableDbs, ['English', 'Spanish']);
-  //   expect(sortedData).toEqual(expectedSortByEnglish);
-  // });
+  it('should correctly sort [English+Spanish] databases numerically and then alphabetically', () => {
+    const sortedData = obj.sortDatabases(sortableDbs, ['English', 'Spanish']);
+    expect(JSON.stringify(sortedData)).toEqual(
+      JSON.stringify(expectedSortByEnglish)
+    );
+  });
 });
 
 // WE SHOULD HAVE A UNIT TESTS FOR getBestBySubject -- needs some stubs or fakes and I don't want to learn how!!!!!

--- a/models/libGuides/test/LibAppsDataFilter.test.js
+++ b/models/libGuides/test/LibAppsDataFilter.test.js
@@ -254,6 +254,37 @@ describe('LibAppsDataFilter: getSubjectsByExpertEmail', () => {
   });
 });
 
+describe('alphaSortByProperty', () => {
+  it('should correctly sort words alphabetically', () => {
+    const startLower = [
+      { animal: 'llama', number: 14 },
+      { animal: 'turtle', number: 3 },
+      { animal: 'otter', number: 9 },
+    ];
+    const expectedLower = [
+      { animal: 'llama', number: 14 },
+      { animal: 'otter', number: 9 },
+      { animal: 'turtle', number: 3 },
+    ];
+    const result = obj.alphaSortByProperty(startLower, 'animal');
+    expect(result).toEqual(expectedLower);
+  });
+  it('should correctly sort words alphabetically case-insensitive', () => {
+    const startMixed = [
+      { animal: 'llama', number: 14 },
+      { animal: 'turtle', number: 3 },
+      { animal: 'Otter', number: 9 },
+    ];
+    const expectedMixed = [
+      { animal: 'llama', number: 14 },
+      { animal: 'Otter', number: 9 },
+      { animal: 'turtle', number: 3 },
+    ];
+    const result = obj.alphaSortByProperty(startMixed, 'animal');
+    expect(result).toEqual(expectedMixed);
+  });
+});
+
 describe('sortDatabases', () => {
   // sort databases by featured status and by name for the relevant subject(s)
   // for featured >0, sort by featured (numerical 1-infinity), then alpha by name

--- a/models/libGuides/test/LibAppsDataFilter.test.js
+++ b/models/libGuides/test/LibAppsDataFilter.test.js
@@ -8,7 +8,9 @@ guides = require('./sample-data/libapps/guides-sample');
 subjects = require('./sample-data/libapps/subj-sample');
 const {
   sortableDbs,
-  expectedSort,
+  expectedSortByEnglish,
+  expectedSortBySpanish,
+  expectedSortByBoth,
 } = require('./sample-data/libapps/db-sort-sample.js');
 
 describe('LibAppsDataFilter', () => {
@@ -254,13 +256,21 @@ describe('LibAppsDataFilter: getSubjectsByExpertEmail', () => {
 });
 
 describe('sortDatabases', () => {
-  it('should correctly sort database numerically and then alphabetically', () => {
-    // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
-    // then do an alpha sort of featured == 0 and append to the end
-
-    const sortedData = obj.sortDatabases(sortableDbs);
-    expect(sortedData).toEqual(expectedSort);
+  // sort databases by featured status and by name for the relevant subject(s)
+  // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
+  // then do an alpha sort of featured == 0 and append to the end
+  it('should correctly sort English databases numerically and then alphabetically', () => {
+    const sortedData = obj.sortDatabases(sortableDbs, ['English']);
+    expect(sortedData).toEqual(expectedSortByEnglish);
   });
+  it('should correctly sort Spanish databases numerically and then alphabetically', () => {
+    const sortedData = obj.sortDatabases(sortableDbs, ['Spanish']);
+    expect(sortedData).toEqual(expectedSortBySpanish);
+  });
+  // it('should correctly sort [English+Spanish] databases numerically and then alphabetically', () => {
+  //   const sortedData = obj.sortDatabases(sortableDbs, ['English', 'Spanish']);
+  //   expect(sortedData).toEqual(expectedSortByEnglish);
+  // });
 });
 
 // WE SHOULD HAVE A UNIT TESTS FOR getBestBySubject -- needs some stubs or fakes and I don't want to learn how!!!!!

--- a/models/libGuides/test/LibAppsDataFilter.test.js
+++ b/models/libGuides/test/LibAppsDataFilter.test.js
@@ -260,11 +260,11 @@ describe('sortDatabases', () => {
   // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
   // then do an alpha sort of featured == 0 and append to the end
   it('should correctly sort English databases numerically and then alphabetically', () => {
-    const sortedData = obj.sortDatabases(sortableDbs, ['English']);
+    const sortedData = obj.sortDatabases(sortableDbs, [{ name: 'English' }]);
     expect(sortedData).toEqual(expectedSortByEnglish);
   });
   it('should correctly sort Spanish databases numerically and then alphabetically', () => {
-    const sortedData = obj.sortDatabases(sortableDbs, ['Spanish']);
+    const sortedData = obj.sortDatabases(sortableDbs, [{ name: 'Spanish' }]);
     expect(sortedData).toEqual(expectedSortBySpanish);
   });
   // it('should correctly sort [English+Spanish] databases numerically and then alphabetically', () => {

--- a/models/libGuides/test/LibAppsDataFilter.test.js
+++ b/models/libGuides/test/LibAppsDataFilter.test.js
@@ -253,63 +253,15 @@ describe('LibAppsDataFilter: getSubjectsByExpertEmail', () => {
   });
 });
 
-describe('alphaSortByProperty', () => {
-  it('should correctly sort words alphabetically', () => {
-    const startLower = [
-      { animal: 'llama', number: 14 },
-      { animal: 'turtle', number: 3 },
-      { animal: 'otter', number: 9 },
-    ];
-    const expectedLower = [
-      { animal: 'llama', number: 14 },
-      { animal: 'otter', number: 9 },
-      { animal: 'turtle', number: 3 },
-    ];
-    const result = obj.alphaSortByProperty(startLower, 'animal');
-    expect(result).toEqual(expectedLower);
-  });
-  it('should correctly sort words alphabetically case-insensitive', () => {
-    const startMixed = [
-      { animal: 'llama', number: 14 },
-      { animal: 'turtle', number: 3 },
-      { animal: 'Otter', number: 9 },
-    ];
-    const expectedMixed = [
-      { animal: 'llama', number: 14 },
-      { animal: 'Otter', number: 9 },
-      { animal: 'turtle', number: 3 },
-    ];
-    const result = obj.alphaSortByProperty(startMixed, 'animal');
-    expect(result).toEqual(expectedMixed);
+describe('sortDatabases', () => {
+  it('should correctly sort database numerically and then alphabetically', () => {
+    // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
+    // then do an alpha sort of featured == 0 and append to the end
+
+    const sortedData = obj.sortDatabases(sortableDbs);
+    expect(sortedData).toEqual(expectedSort);
   });
 });
-
-describe('numericSortByProperty', () => {
-  const startNumeric = [
-    { animal: 'llama', number: 14 },
-    { animal: 'turtle', number: 3 },
-    { animal: 'otter', number: 9 },
-  ];
-  const expectedNumeric = [
-    { animal: 'turtle', number: 3 },
-    { animal: 'otter', number: 9 },
-    { animal: 'llama', number: 14 },
-  ];
-  it('should correctly sort objects numerically by a given property', () => {
-    const result = obj.numericSortByProperty(startNumeric, 'number');
-    expect(result).toEqual(expectedNumeric);
-  });
-});
-
-// describe('sortDatabases', () => {
-//   it('should correctly sort database numerically and then alphabetically', () => {
-//     // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
-//     // then do an alpha sort of featured == 0 and append to the end
-
-//     const sortedData = obj.sortDatabases(sortableDbs);
-//     expect(sortedData).toEqual(expectedSort);
-//   });
-// });
 
 // WE SHOULD HAVE A UNIT TESTS FOR getBestBySubject -- needs some stubs or fakes and I don't want to learn how!!!!!
 

--- a/models/libGuides/test/LibAppsDataFilter.test.js
+++ b/models/libGuides/test/LibAppsDataFilter.test.js
@@ -6,6 +6,10 @@ databases = require('./sample-data/libapps/db-sample');
 librarians = require('./sample-data/libapps/libn-sample');
 guides = require('./sample-data/libapps/guides-sample');
 subjects = require('./sample-data/libapps/subj-sample');
+const {
+  sortableDbs,
+  expectedSort,
+} = require('./sample-data/libapps/db-sort-sample.js');
 
 describe('LibAppsDataFilter', () => {
   it('should return an object of class LibAppsDataFilter', () => {
@@ -248,6 +252,64 @@ describe('LibAppsDataFilter: getSubjectsByExpertEmail', () => {
     expect(subjects.length).toBe(0);
   });
 });
+
+describe('alphaSortByProperty', () => {
+  it('should correctly sort words alphabetically', () => {
+    const startLower = [
+      { animal: 'llama', number: 14 },
+      { animal: 'turtle', number: 3 },
+      { animal: 'otter', number: 9 },
+    ];
+    const expectedLower = [
+      { animal: 'llama', number: 14 },
+      { animal: 'otter', number: 9 },
+      { animal: 'turtle', number: 3 },
+    ];
+    const result = obj.alphaSortByProperty(startLower, 'animal');
+    expect(result).toEqual(expectedLower);
+  });
+  it('should correctly sort words alphabetically case-insensitive', () => {
+    const startMixed = [
+      { animal: 'llama', number: 14 },
+      { animal: 'turtle', number: 3 },
+      { animal: 'Otter', number: 9 },
+    ];
+    const expectedMixed = [
+      { animal: 'llama', number: 14 },
+      { animal: 'Otter', number: 9 },
+      { animal: 'turtle', number: 3 },
+    ];
+    const result = obj.alphaSortByProperty(startMixed, 'animal');
+    expect(result).toEqual(expectedMixed);
+  });
+});
+
+describe('numericSortByProperty', () => {
+  const startNumeric = [
+    { animal: 'llama', number: 14 },
+    { animal: 'turtle', number: 3 },
+    { animal: 'otter', number: 9 },
+  ];
+  const expectedNumeric = [
+    { animal: 'turtle', number: 3 },
+    { animal: 'otter', number: 9 },
+    { animal: 'llama', number: 14 },
+  ];
+  it('should correctly sort objects numerically by a given property', () => {
+    const result = obj.numericSortByProperty(startNumeric, 'number');
+    expect(result).toEqual(expectedNumeric);
+  });
+});
+
+// describe('sortDatabases', () => {
+//   it('should correctly sort database numerically and then alphabetically', () => {
+//     // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
+//     // then do an alpha sort of featured == 0 and append to the end
+
+//     const sortedData = obj.sortDatabases(sortableDbs);
+//     expect(sortedData).toEqual(expectedSort);
+//   });
+// });
 
 // WE SHOULD HAVE A UNIT TESTS FOR getBestBySubject -- needs some stubs or fakes and I don't want to learn how!!!!!
 

--- a/models/libGuides/test/LibAppsDataFilter.test.js
+++ b/models/libGuides/test/LibAppsDataFilter.test.js
@@ -260,11 +260,11 @@ describe('sortDatabases', () => {
   // for featured >0, sort by featured (numerical 1-infinity), then alpha by name
   // then do an alpha sort of featured == 0 and append to the end
   it('should correctly sort English databases numerically and then alphabetically', () => {
-    const sortedData = obj.sortDatabases(sortableDbs, [{ name: 'English' }]);
+    const sortedData = obj.sortDatabases(sortableDbs, ['English']);
     expect(sortedData).toEqual(expectedSortByEnglish);
   });
   it('should correctly sort Spanish databases numerically and then alphabetically', () => {
-    const sortedData = obj.sortDatabases(sortableDbs, [{ name: 'Spanish' }]);
+    const sortedData = obj.sortDatabases(sortableDbs, ['Spanish']);
     expect(sortedData).toEqual(expectedSortBySpanish);
   });
   // it('should correctly sort [English+Spanish] databases numerically and then alphabetically', () => {

--- a/models/libGuides/test/sample-data/libapps/db-sort-sample.js
+++ b/models/libGuides/test/sample-data/libapps/db-sort-sample.js
@@ -152,61 +152,67 @@ const expectedSortBySpanish = [
     ],
   },
 ];
-const expectedSortByBoth = [
-  {
-    name: 'Access Complete',
-    subjects: [
-      { name: 'English', featured: 1 },
-      { name: 'Spanish', featured: 0 },
-    ],
-  },
-  {
-    name: 'Green Eggs and Ham',
-    subjects: [
-      { name: 'English', featured: 1 },
-      { name: 'Spanish', featured: 0 },
-    ],
-  },
-  {
-    name: 'MLA',
-    subjects: [
-      { name: 'English', featured: 1 },
-      { name: 'Spanish', featured: 0 },
-    ],
-  },
-  {
-    name: 'Monkeys',
-    subjects: [
-      { name: 'English', featured: 3 },
-      { name: 'Spanish', featured: 1 },
-    ],
-  },
-  {
-    name: 'Comm Abstracts',
-    subjects: [
-      { name: 'English', featured: 0 },
-      { name: 'Spanish', featured: 2 },
-    ],
-  },
-  {
-    name: 'Journal of Tree Frogs',
-    subjects: [
-      { name: 'English', featured: 2 },
-      { name: 'Spanish', featured: 0 },
-    ],
-  },
-  {
-    name: 'Theatre Index',
-    subjects: [
-      { name: 'English', featured: 0 },
-      { name: 'Spanish', featured: 0 },
-    ],
-  },
-];
+// the following object was written based on a misunderstanding of how myguide handles
+// multiple subject listings. The current approach is that the first one is the default
+// and if there's no content, then it falls back to the second. It is *not* a mix of the two.
+// We may want to reconsider that in the future but this is commented out so we test for
+// the current realities.
+//
+// const expectedSortByBoth = [
+//   {
+//     name: 'Access Complete',
+//     subjects: [
+//       { name: 'English', featured: 1 },
+//       { name: 'Spanish', featured: 0 },
+//     ],
+//   },
+//   {
+//     name: 'Green Eggs and Ham',
+//     subjects: [
+//       { name: 'English', featured: 1 },
+//       { name: 'Spanish', featured: 0 },
+//     ],
+//   },
+//   {
+//     name: 'MLA',
+//     subjects: [
+//       { name: 'English', featured: 1 },
+//       { name: 'Spanish', featured: 0 },
+//     ],
+//   },
+//   {
+//     name: 'Monkeys',
+//     subjects: [
+//       { name: 'English', featured: 3 },
+//       { name: 'Spanish', featured: 1 },
+//     ],
+//   },
+//   {
+//     name: 'Comm Abstracts',
+//     subjects: [
+//       { name: 'English', featured: 0 },
+//       { name: 'Spanish', featured: 2 },
+//     ],
+//   },
+//   {
+//     name: 'Journal of Tree Frogs',
+//     subjects: [
+//       { name: 'English', featured: 2 },
+//       { name: 'Spanish', featured: 0 },
+//     ],
+//   },
+//   {
+//     name: 'Theatre Index',
+//     subjects: [
+//       { name: 'English', featured: 0 },
+//       { name: 'Spanish', featured: 0 },
+//     ],
+//   },
+// ];
 
 module.exports = {
   sortableDbs,
   expectedSortByEnglish,
   expectedSortBySpanish,
-  expectedSortByBoth,
+  // expectedSortByBoth,
 };

--- a/models/libGuides/test/sample-data/libapps/db-sort-sample.js
+++ b/models/libGuides/test/sample-data/libapps/db-sort-sample.js
@@ -1,0 +1,63 @@
+const sortableDbs = [
+  {
+    name: 'Monkeys',
+    featured: 3,
+  },
+  {
+    name: 'Journal of Tree Frogs',
+    featured: 2,
+  },
+  {
+    name: 'Comm Abstracts',
+    featured: 0,
+  },
+  {
+    name: 'Access Complete',
+    featured: 1,
+  },
+  {
+    name: 'MLA',
+    featured: 1,
+  },
+  {
+    name: 'Green Eggs and Ham',
+    featured: 1,
+  },
+  {
+    name: 'Theatre Index',
+    featured: 0,
+  },
+];
+
+const expectedSort = [
+  {
+    name: 'Access Complete',
+    featured: 1,
+  },
+  {
+    name: 'Green Eggs and Ham',
+    featured: 1,
+  },
+  {
+    name: 'MLA',
+    featured: 1,
+  },
+  {
+    name: 'Journal of Tree Frogs',
+    featured: 2,
+  },
+  {
+    name: 'Monkeys',
+    featured: 3,
+  },
+  {
+    name: 'Comm Abstracts',
+    featured: 0,
+  },
+  {
+    name: 'Theatre Index',
+    featured: 0,
+  },
+];
+
+module.exports = { sortableDbs, expectedSort };

--- a/models/libGuides/test/sample-data/libapps/db-sort-sample.js
+++ b/models/libGuides/test/sample-data/libapps/db-sort-sample.js
@@ -1,63 +1,212 @@
 const sortableDbs = [
   {
     name: 'Monkeys',
-    featured: 3,
+    subjects: [
+      { name: 'English', featured: 3 },
+      { name: 'Spanish', featured: 1 },
+    ],
   },
   {
     name: 'Journal of Tree Frogs',
-    featured: 2,
+    subjects: [
+      { name: 'English', featured: 2 },
+      { name: 'Spanish', featured: 0 },
+    ],
   },
   {
     name: 'Comm Abstracts',
-    featured: 0,
+    subjects: [
+      { name: 'English', featured: 0 },
+      { name: 'Spanish', featured: 2 },
+    ],
   },
   {
     name: 'Access Complete',
-    featured: 1,
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
   },
   {
     name: 'MLA',
-    featured: 1,
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
   },
   {
     name: 'Green Eggs and Ham',
-    featured: 1,
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
   },
   {
     name: 'Theatre Index',
-    featured: 0,
+    subjects: [
+      { name: 'English', featured: 0 },
+      { name: 'Spanish', featured: 0 },
+    ],
   },
 ];
 
-const expectedSort = [
+const expectedSortByEnglish = [
   {
     name: 'Access Complete',
-    featured: 1,
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
   },
   {
     name: 'Green Eggs and Ham',
-    featured: 1,
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
   },
   {
     name: 'MLA',
-    featured: 1,
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
   },
   {
     name: 'Journal of Tree Frogs',
-    featured: 2,
+    subjects: [
+      { name: 'English', featured: 2 },
+      { name: 'Spanish', featured: 0 },
+    ],
   },
   {
     name: 'Monkeys',
-    featured: 3,
+    subjects: [
+      { name: 'English', featured: 3 },
+      { name: 'Spanish', featured: 1 },
+    ],
   },
   {
     name: 'Comm Abstracts',
-    featured: 0,
+    subjects: [
+      { name: 'English', featured: 0 },
+      { name: 'Spanish', featured: 2 },
+    ],
   },
   {
     name: 'Theatre Index',
-    featured: 0,
+    subjects: [
+      { name: 'English', featured: 0 },
+      { name: 'Spanish', featured: 0 },
+    ],
+  },
+];
+const expectedSortBySpanish = [
+  {
+    name: 'Monkeys',
+    subjects: [
+      { name: 'English', featured: 3 },
+      { name: 'Spanish', featured: 1 },
+    ],
+  },
+  {
+    name: 'Comm Abstracts',
+    subjects: [
+      { name: 'English', featured: 0 },
+      { name: 'Spanish', featured: 2 },
+    ],
+  },
+  {
+    name: 'Access Complete',
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
+  },
+  {
+    name: 'Green Eggs and Ham',
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
+  },
+  {
+    name: 'Journal of Tree Frogs',
+    subjects: [
+      { name: 'English', featured: 2 },
+      { name: 'Spanish', featured: 0 },
+    ],
+  },
+  {
+    name: 'MLA',
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
+  },
+  {
+    name: 'Theatre Index',
+    subjects: [
+      { name: 'English', featured: 0 },
+      { name: 'Spanish', featured: 0 },
+    ],
+  },
+];
+const expectedSortByBoth = [
+  {
+    name: 'Access Complete',
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
+  },
+  {
+    name: 'Green Eggs and Ham',
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
+  },
+  {
+    name: 'MLA',
+    subjects: [
+      { name: 'English', featured: 1 },
+      { name: 'Spanish', featured: 0 },
+    ],
+  },
+  {
+    name: 'Monkeys',
+    subjects: [
+      { name: 'English', featured: 3 },
+      { name: 'Spanish', featured: 1 },
+    ],
+  },
+  {
+    name: 'Comm Abstracts',
+    subjects: [
+      { name: 'English', featured: 0 },
+      { name: 'Spanish', featured: 2 },
+    ],
+  },
+  {
+    name: 'Journal of Tree Frogs',
+    subjects: [
+      { name: 'English', featured: 2 },
+      { name: 'Spanish', featured: 0 },
+    ],
+  },
+  {
+    name: 'Theatre Index',
+    subjects: [
+      { name: 'English', featured: 0 },
+      { name: 'Spanish', featured: 0 },
+    ],
   },
 ];
 
-module.exports = { sortableDbs, expectedSort };
+module.exports = {
+  sortableDbs,
+  expectedSortByEnglish,
+  expectedSortBySpanish,
+  expectedSortByBoth,
+};

--- a/utilities/updateSubjectCache.js
+++ b/utilities/updateSubjectCache.js
@@ -87,7 +87,9 @@ function getLibGuidesData(libguides) {
     rightGroups = f.removeWrongGroups(pubGuides, allowedGroups);
 
     gds = f.getBestBySubject(rightGroups, libguides);
-    dbs = f.getBestBySubject(databases, libguides, true); // true = topOnly
+    dbs = f.getBestBySubject(databases, libguides, true, true); // true = topOnly
+    // dbs = f.sortDatabases(dbs, subj);
+    // dbs = f.sortDatabases(dbs);
     let results = {
       metadata: {
         sizeof: {


### PR DESCRIPTION
* for databases, primarily sort by featured ordinal value (1,2,3); fall back to alpha
  * closes #255 
* for guides, sort alpha
  * closes #254  
* also somewhat randomly fixes a broken test for alma circ display
 